### PR TITLE
Fix: 체크리스트 등록 api,  체크리스트에 내가 담은 아이템 카테고리별 조회 api 수정

### DIFF
--- a/src/main/java/com/tripj/domain/checklist/controller/CheckListController.java
+++ b/src/main/java/com/tripj/domain/checklist/controller/CheckListController.java
@@ -66,10 +66,11 @@ public class CheckListController {
             summary = "체크리스트에 담은 아이템 조회 API",
             description = "체크리스트 > 체크리스트에 내가 담은 아이템 카테고리별 조회"
     )
-    @GetMapping("/checklist")
+    @GetMapping("/added")
     public RestApiResponse <List<GetMyCheckListResponse>> getMyCheckList(Long itemCateId,
-                                                                         Long userId) {
-        return RestApiResponse.success(checkListService.getMyCheckList(itemCateId, userId));
+                                                                         Long userId,
+                                                                         Long tripId) {
+        return RestApiResponse.success(checkListService.getMyCheckList(itemCateId, userId, tripId));
     }
 
 

--- a/src/main/java/com/tripj/domain/checklist/model/dto/CreateCheckListRequest.java
+++ b/src/main/java/com/tripj/domain/checklist/model/dto/CreateCheckListRequest.java
@@ -2,15 +2,21 @@ package com.tripj.domain.checklist.model.dto;
 
 import com.tripj.domain.checklist.model.entity.CheckList;
 import com.tripj.domain.item.model.entity.Item;
+import com.tripj.domain.trip.model.entity.Trip;
 import com.tripj.domain.user.model.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class CreateCheckListRequest {
 
+    @Schema(description = "아이템 카테고리 Id", example = "1")
     private Long itemId;
 
-    public CheckList toEntity(Item item, User user) {
-        return CheckList.newCheckList(item, user);
+    @Schema(description = "여행 Id", example = "1")
+    private Long tripId;
+
+    public CheckList toEntity(Item item, User user, Trip trip) {
+        return CheckList.newCheckList(item, user, trip);
     }
 }

--- a/src/main/java/com/tripj/domain/checklist/model/dto/GetMyCheckListResponse.java
+++ b/src/main/java/com/tripj/domain/checklist/model/dto/GetMyCheckListResponse.java
@@ -20,13 +20,18 @@ public class GetMyCheckListResponse {
     @Schema(description = "아이템 카테고리 명", example = "의류")
     private String itemCateName;
 
+    @Schema(description = "여행 이름", example = "즐거운 오사카 여행")
+    private String tripName;
+
     @QueryProjection
     public GetMyCheckListResponse(Long checkListId,
                                   String itemName,
-                                  String itemCateName) {
+                                  String itemCateName,
+                                  String tripName) {
         this.checkListId = checkListId;
         this.itemName = itemName;
         this.itemCateName = itemCateName;
+        this.tripName = tripName;
     }
 
 }

--- a/src/main/java/com/tripj/domain/checklist/model/dto/PackCheckListRequest.java
+++ b/src/main/java/com/tripj/domain/checklist/model/dto/PackCheckListRequest.java
@@ -1,9 +1,14 @@
 package com.tripj.domain.checklist.model.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class PackCheckListRequest {
+
+    @Schema(description = "체크리스트 Id", example = "1")
     private Long checklistId;
+
+    @Schema(description = "챙김 여부", example = "NO")
     private String pack;
 }

--- a/src/main/java/com/tripj/domain/checklist/model/entity/CheckList.java
+++ b/src/main/java/com/tripj/domain/checklist/model/entity/CheckList.java
@@ -2,6 +2,7 @@ package com.tripj.domain.checklist.model.entity;
 
 import com.tripj.domain.common.entity.BaseTimeEntity;
 import com.tripj.domain.item.model.entity.Item;
+import com.tripj.domain.trip.model.entity.Trip;
 import com.tripj.domain.user.model.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -23,6 +24,10 @@ public class CheckList extends BaseTimeEntity {
     private Item item;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id")
+    private Trip trip;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
@@ -30,10 +35,11 @@ public class CheckList extends BaseTimeEntity {
 
     private String previous;
 
-    public static CheckList newCheckList(Item item, User user) {
+    public static CheckList newCheckList(Item item, User user, Trip trip) {
         return CheckList.builder()
                 .item(item)
                 .user(user)
+                .trip(trip)
                 .pack("NO")
                 .previous("NOW")
                 .build();

--- a/src/main/java/com/tripj/domain/checklist/repository/CheckListRepositoryCustom.java
+++ b/src/main/java/com/tripj/domain/checklist/repository/CheckListRepositoryCustom.java
@@ -9,6 +9,6 @@ import java.util.List;
 public interface CheckListRepositoryCustom {
 
     List<GetCheckListResponse> getCheckList(Long itemCateId, Long userId, Long countryId);
-    List<GetMyCheckListResponse> getMyCheckList(Long itemCateId, Long userId);
+    List<GetMyCheckListResponse> getMyCheckList(Long itemCateId, Long userId, Long tripId);
 
 }

--- a/src/main/java/com/tripj/domain/checklist/repository/CheckListRepositoryCustomImpl.java
+++ b/src/main/java/com/tripj/domain/checklist/repository/CheckListRepositoryCustomImpl.java
@@ -3,12 +3,14 @@ package com.tripj.domain.checklist.repository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.tripj.domain.checklist.model.dto.*;
 import com.tripj.domain.checklist.model.entity.QCheckList;
+import com.tripj.domain.trip.model.entity.QTrip;
 
 import java.util.List;
 
 import static com.tripj.domain.checklist.model.entity.QCheckList.*;
 import static com.tripj.domain.item.model.entity.QItem.item;
 import static com.tripj.domain.itemcate.model.entity.QItemCate.itemCate;
+import static com.tripj.domain.trip.model.entity.QTrip.*;
 
 public class CheckListRepositoryCustomImpl implements CheckListRepositoryCustom {
 
@@ -44,19 +46,22 @@ public class CheckListRepositoryCustomImpl implements CheckListRepositoryCustom 
     }
 
     @Override
-    public List<GetMyCheckListResponse> getMyCheckList(Long itemCateId, Long userId) {
+    public List<GetMyCheckListResponse> getMyCheckList(Long itemCateId, Long userId, Long tripId) {
         List<GetMyCheckListResponse> results = queryFactory
                         .select(new QGetMyCheckListResponse(
                                 checkList.id,
                                 checkList.item.itemName,
-                                itemCate.itemCateName
+                                itemCate.itemCateName,
+                                trip.tripName
                         ))
                         .from(checkList)
                         .join(checkList.item, item)
                         .join(item.itemCate, itemCate)
+                        .join(checkList.trip, trip)
                         .where(
                                 item.itemCate.Id.eq(itemCateId),
-                                checkList.user.id.eq(userId)
+                                checkList.user.id.eq(userId),
+                                checkList.trip.id.eq(tripId)
                         )
                         .fetch();
 

--- a/src/main/java/com/tripj/domain/checklist/service/CheckListService.java
+++ b/src/main/java/com/tripj/domain/checklist/service/CheckListService.java
@@ -5,6 +5,8 @@ import com.tripj.domain.checklist.model.entity.CheckList;
 import com.tripj.domain.checklist.repository.CheckListRepository;
 import com.tripj.domain.item.model.entity.Item;
 import com.tripj.domain.item.repository.ItemRepository;
+import com.tripj.domain.trip.model.entity.Trip;
+import com.tripj.domain.trip.repository.TripRepository;
 import com.tripj.domain.user.model.entity.User;
 import com.tripj.domain.user.repository.UserRepository;
 import com.tripj.global.code.ErrorCode;
@@ -26,6 +28,7 @@ public class CheckListService {
     private final CheckListRepository checkListRepository;
     private final UserRepository userRepository;
     private final ItemRepository itemRepository;
+    private final TripRepository tripRepository;
 
     /**
      * 체크리스트 조회
@@ -42,8 +45,12 @@ public class CheckListService {
      */
     public CreateCheckListResponse createCheckList(CreateCheckListRequest request,
                                                    Long userId) {
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.E404_NOT_EXISTS_USER));
+
+        Trip trip = tripRepository.findById(request.getTripId())
+                .orElseThrow(() -> new NotFoundException(ErrorCode.E404_NOT_EXISTS_TRIP));
 
         Item item = itemRepository.findById(request.getItemId())
                 .orElseThrow(() -> new NotFoundException(ErrorCode.E404_NOT_EXISTS_ITEM));
@@ -54,7 +61,7 @@ public class CheckListService {
             throw new BusinessException(ErrorCode.ALREADY_EXISTS_CHECKLIST);
         }
 
-        CheckList savedCheckList = checkListRepository.save(request.toEntity(item, user));
+        CheckList savedCheckList = checkListRepository.save(request.toEntity(item, user, trip));
 
         return CreateCheckListResponse.of(savedCheckList.getId());
     }
@@ -137,8 +144,11 @@ public class CheckListService {
      * 내 체크리스트 조회
      */
     @Transactional(readOnly = true)
-    public List<GetMyCheckListResponse> getMyCheckList(Long itemCateId, Long userId) {
-        return checkListRepository.getMyCheckList(itemCateId, userId);
+    public List<GetMyCheckListResponse> getMyCheckList(Long itemCateId,
+                                                       Long userId,
+                                                       Long tripId) {
+
+        return checkListRepository.getMyCheckList(itemCateId, userId, tripId);
     }
 
 }


### PR DESCRIPTION
## 🖥️ 작업내용
- 체크리스트 등록, 내가 담은 아이템 카테고리별 조회시 tripId 파라미터 추가
- 여행 - 체크리스트 (1:N) 연관관계 설정
- 연관관계 없어도 로직에 문제 없을줄 알았으나, 지난 여행과 현재여행 구분을 하기 위해서 필요 😭 