### PR TITLE
Chore: cannot find symbol 이슈로 build.gradle에 querydsl 세팅 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,8 +106,23 @@ dependencyManagement {
 }
 
 
+
 //***************** querydsl 추가 시작 *********************//
+def generated = "src/main/generated"
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
 clean {
+	delete file(generated)
 	delete file('src/main/generated')
 }
 //******************** querydsl 추가 끝 *********************//


### PR DESCRIPTION
## 💡 **개요**
- cannot find symbol 이슈로 build.gradle에 querydsl 세팅 수정
## 📑 **작업 사항**
- QClass 관련 세팅 추가
